### PR TITLE
Added pre-commit hooks for python and django upgrades

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,14 @@
 repos:
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.31.0
+  hooks:
+    - id: pyupgrade
+      args: [ "--py37-plus" ]
+- repo: https://github.com/adamchainz/django-upgrade
+  rev: '1.4.0'
+  hooks:
+    - id: django-upgrade
+      args: [ --target-version, "2.2" ]
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1
   hooks:

--- a/djangocms_frontend/frameworks/bootstrap5.py
+++ b/djangocms_frontend/frameworks/bootstrap5.py
@@ -1,5 +1,3 @@
-import json
-
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext
@@ -34,7 +32,6 @@ COLOR_CODES = getattr(
     "DJANGOCMS_FRONTEND_COLOR_CODES",
     dict(),
 )
-
 
 FORM_TEMPLATE = getattr(
     settings,
@@ -107,7 +104,6 @@ SIZE_Y_CHOICES = getattr(
         ("min-vh-100", _("Screen (minimum)")),
     ),
 )
-
 
 OPACITY_CHOICES = getattr(
     settings,

--- a/djangocms_frontend/management/commands/subcommands/base.py
+++ b/djangocms_frontend/management/commands/subcommands/base.py
@@ -76,7 +76,7 @@ class SubcommandsCommand(BaseCommand):
     def create_parser(self, prog_name, subcommand, **kwargs):
         kwargs = {}
         parser = CommandParser(
-            prog="%s %s" % (os.path.basename(prog_name), subcommand),
+            prog=f"{os.path.basename(prog_name)} {subcommand}",
             description=self.help or None,
             **kwargs
         )

--- a/djangocms_frontend/management/commands/subcommands/base.py
+++ b/djangocms_frontend/management/commands/subcommands/base.py
@@ -78,7 +78,7 @@ class SubcommandsCommand(BaseCommand):
         parser = CommandParser(
             prog=f"{os.path.basename(prog_name)} {subcommand}",
             description=self.help or None,
-            **kwargs
+            **kwargs,
         )
         add_builtin_arguments(parser)
         self.add_arguments(parser)
@@ -98,7 +98,7 @@ class SubcommandsCommand(BaseCommand):
                     name=instance.command_name,
                     help=instance.help_string,
                     description=instance.help_string,
-                    **kwargs
+                    **kwargs,
                 )
 
                 add_builtin_arguments(parser=parser_sub)

--- a/djangocms_frontend/templatetags/frontend.py
+++ b/djangocms_frontend/templatetags/frontend.py
@@ -45,7 +45,7 @@ class LazyEncoder(DjangoJSONEncoder):
     def default(self, obj):
         if isinstance(obj, Promise):
             return force_text(obj)
-        return super(LazyEncoder, self).default(obj)
+        return super().default(obj)
 
 
 @register.filter

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -20,7 +20,9 @@ class TestFixture:
         self.page.publish(self.language)
         self.placeholder = self.page.placeholders.get(slot="content")
         self.superuser = self.get_superuser()
-        self.request_url = self.page.get_absolute_url(self.language) + "?toolbar_off=true"
+        self.request_url = (
+            self.page.get_absolute_url(self.language) + "?toolbar_off=true"
+        )
 
         return super().setUp()
 

--- a/tests/grid/test_plugins.py
+++ b/tests/grid/test_plugins.py
@@ -140,5 +140,5 @@ class GridPluginTestCase(TestFixture, CMSTestCase):
             # `get_add_plugin_uri` to get cleaner test results
             warnings.simplefilter("ignore")
             response = self.client.post(request_url, data)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<div class="success">')

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,6 @@ import os
 from tempfile import mkdtemp
 
 from django.core.files import File
-
 from filer.models.filemodels import File as FilerFile
 from filer.models.foldermodels import Folder as FilerFolder
 from filer.models.imagemodels import Image as FilerImage
@@ -65,8 +64,7 @@ def get_file(file_name="test_file.pdf"):
     }
 
 
-def get_filer_image(image_name="test_file.jpg", name="",
-                    original_filename=True):
+def get_filer_image(image_name="test_file.jpg", name="", original_filename=True):
     """
     Creates and stores an image to filer and returns it
 

--- a/tests/media/test_models.py
+++ b/tests/media/test_models.py
@@ -1,12 +1,9 @@
 from django.test import TestCase
 
-from djangocms_frontend.contrib.media.models import (
-    Media, MediaBody,
-)
+from djangocms_frontend.contrib.media.models import Media, MediaBody
 
 
 class MediaModelTestCase(TestCase):
-
     def test_media_instance(self):
         instance = Media.objects.create()
         self.assertEqual(str(instance), "Media (1)")

--- a/tests/tabs/test_models.py
+++ b/tests/tabs/test_models.py
@@ -1,14 +1,13 @@
 from django.test import TestCase
 
-from djangocms_frontend.contrib.tabs.models import (
-    Tab, TabItem,
-)
+from djangocms_frontend.contrib.tabs.models import Tab, TabItem
 
 
 class TabsModelTestCase(TestCase):
-
     def test_tab_instance(self):
-        instance = Tab.objects.create(config=dict(tab_type="nav-tabs", tab_alignment=""))
+        instance = Tab.objects.create(
+            config=dict(tab_type="nav-tabs", tab_alignment="")
+        )
         self.assertEqual(str(instance), "Tab (1)")
         self.assertEqual(instance.get_short_description(), "(nav-tabs)")
         instance.config["tab_alignment"] = "nav-fill"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -14,7 +14,7 @@ class B5ConstantsTestCase(TestCase):
     # when changing any values in these
 
     def test_constants(self):
-        self.assertEquals(
+        self.assertEqual(
             DEVICE_CHOICES,
             (
                 ("xs", "Extra small"),  # default <576px
@@ -25,8 +25,8 @@ class B5ConstantsTestCase(TestCase):
                 ("xxl", "Extra-extra large"),
             ),
         )
-        self.assertEquals(DEVICE_SIZES, ("xs", "sm", "md", "lg", "xl", "xxl"))
-        self.assertEquals(
+        self.assertEqual(DEVICE_SIZES, ("xs", "sm", "md", "lg", "xl", "xxl"))
+        self.assertEqual(
             TAG_CHOICES,
             (
                 ("div", "div"),
@@ -37,7 +37,7 @@ class B5ConstantsTestCase(TestCase):
                 ("aside", "aside"),
             ),
         )
-        self.assertEquals(
+        self.assertEqual(
             COLOR_STYLE_CHOICES,
             (
                 ("primary", "Primary"),
@@ -50,7 +50,7 @@ class B5ConstantsTestCase(TestCase):
                 ("dark", "Dark"),
             ),
         )
-        self.assertEquals(
+        self.assertEqual(
             ALIGN_CHOICES,
             (
                 ("start", "Left"),

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -26,4 +26,4 @@ class MigrationTestCase(TestCase):
             status_code = "0"
 
         if status_code == "1":
-            self.fail("There are missing migrations:\n {}".format(output.getvalue()))
+            self.fail(f"There are missing migrations:\n {output.getvalue()}")


### PR DESCRIPTION
This adds pre-commit hooks for django and python upgrades, which makes upgrading version support in future really easy and keeps code as efficient as the minimum version allows.

I've also ran all hooks on the app sequentially through the commits here.